### PR TITLE
Escape to close `.expanded` elements

### DIFF
--- a/public/lib.js
+++ b/public/lib.js
@@ -265,6 +265,7 @@ function addImageByUrl(
      imageContainer.classList.remove('expanded')
     } else {
      imageContainer.classList.add('expanded')
+     imageContainer.focus()
     }
    },
    keydown({ key }) {

--- a/public/lib.js
+++ b/public/lib.js
@@ -267,6 +267,16 @@ function addImageByUrl(
      imageContainer.classList.add('expanded')
     }
    },
+   keydown({ key }) {
+    if (
+     imageContainer.classList.contains(
+      'expanded'
+     ) &&
+     key === 'Escape'
+    ) {
+     imageContainer.classList.remove('expanded')
+    }
+   },
   },
  })
  container.appendChild(imageContainer)

--- a/public/lib.js
+++ b/public/lib.js
@@ -263,19 +263,10 @@ function addImageByUrl(
      )
     ) {
      imageContainer.classList.remove('expanded')
+     expandedElement = undefined
     } else {
      imageContainer.classList.add('expanded')
-     imageContainer.focus()
-    }
-   },
-   keydown({ key }) {
-    if (
-     imageContainer.classList.contains(
-      'expanded'
-     ) &&
-     key === 'Escape'
-    ) {
-     imageContainer.classList.remove('expanded')
+     expandedElement = imageContainer
     }
    },
   },

--- a/public/main.js
+++ b/public/main.js
@@ -1,11 +1,10 @@
 const HOME_CHANNEL_ICON = '⌂'
 const ONE_HOUR_MS = 60 * 60 * 1000
 
+let channelInputFocused = false
 let expandedElement = undefined
-
 let focusOnMessage = undefined
 let lastKnownChannelInput
-let channelInputFocused = false
 const channelInput = elem({
  attributes: {
   maxlength: 25,

--- a/public/main.js
+++ b/public/main.js
@@ -1,6 +1,8 @@
 const HOME_CHANNEL_ICON = '⌂'
 const ONE_HOUR_MS = 60 * 60 * 1000
 
+let expandedElement = undefined
+
 let focusOnMessage = undefined
 let lastKnownChannelInput
 let channelInputFocused = false
@@ -53,21 +55,17 @@ const autocompleteChannels =
 
 addEventListener('keydown', ({ key }) => {
  if (key === 'Escape') {
-  const expanded =
-   document.getElementsByClassName('expanded')
-  if (expanded.length < 1) {
+  if (expandedElement === undefined) {
    if (channelInputFocused) {
     cancelChannelInput()
     channelInput.blur()
    } else {
     channelInput.focus()
    }
+  } else {
+   expandedElement.classList.remove('expanded')
+   expandedElement = undefined
   }
-  Array.prototype.slice
-   .call(expanded)
-   .forEach((element) => {
-    element.classList.remove('expanded')
-   })
  }
 })
 

--- a/public/main.js
+++ b/public/main.js
@@ -53,12 +53,21 @@ const autocompleteChannels =
 
 addEventListener('keydown', ({ key }) => {
  if (key === 'Escape') {
-  if (channelInputFocused) {
-   cancelChannelInput()
-   channelInput.blur()
-  } else {
-   channelInput.focus()
+  const expanded =
+   document.getElementsByClassName('expanded')
+  if (expanded.length < 1) {
+   if (channelInputFocused) {
+    cancelChannelInput()
+    channelInput.blur()
+   } else {
+    channelInput.focus()
+   }
   }
+  Array.prototype.slice
+   .call(expanded)
+   .forEach((element) => {
+    element.classList.remove('expanded')
+   })
  }
 })
 


### PR DESCRIPTION
This code removes `.expanded` from elements on Escape key.