### PR TITLE
fix: use document scrolling instead of body scrolling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,14 +43,12 @@
   <title>Tag Me In</title>
   <style>
    html {
-    overflow: hidden;
+    overflow: auto;
    }
    body {
     background-color: #000;
     color: #fff;
-    height: 100%;
-    max-height: 100dvh;
-    overflow: auto;
+    min-height: 100dvh;
    }
    body.light-mode {
     background-color: #fff;

--- a/public/js/lib.js
+++ b/public/js/lib.js
@@ -332,17 +332,17 @@ function addImageEmbed(container, text) {
 }
 
 function captureScrollPosition() {
- const scrollPosition = document.body.scrollTop
+ const scrollPosition = window.scrollY
  localStorage.setItem(
   'scrollPosition',
   scrollPosition
  )
- document.body.scrollTo({
+ window.scrollTo({
   behavior: 'instant',
   left: 0,
   top: 0,
  })
- document.body.style.overflow = 'hidden'
+ document.documentElement.style.overflow = 'hidden'
 }
 
 function restoreScrollPosition() {
@@ -350,13 +350,13 @@ function restoreScrollPosition() {
   'scrollPosition'
  )
  if (scrollPosition) {
-  document.body.scrollTo({
+  window.scrollTo({
    behavior: 'instant',
    left: 0,
    top: scrollPosition,
   })
  }
- document.body.style.overflow = 'auto'
+ document.documentElement.style.overflow = 'auto'
 }
 
 // Global image gallery state
@@ -1683,7 +1683,7 @@ async function createSessionWithServer(
 }
 
 function scrollToTop(top = 0) {
- document.body.scrollTo(0, top, {
+ window.scrollTo(0, top, {
   behavior: 'instant',
  })
  document.body.classList.remove('scroll-up')

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -363,14 +363,14 @@ function scrolledPastBottom(
  exemptZeroScroll = false
 ) {
  if (
-  (!exemptZeroScroll && body.scrollTop < 1) ||
+  (!exemptZeroScroll && window.scrollY < 1) ||
   !element.checkVisibility()
  ) {
   return false
  }
  const bottom = Math.ceil(
   document.documentElement.scrollHeight -
-   body.scrollTop -
+   window.scrollY -
    document.documentElement.clientHeight
  )
  const elementBottom = Math.ceil(
@@ -383,10 +383,10 @@ function scrolledPastBottom(
 let lastScrollY = 0
 let addTimeout
 let removeTimeout
-body.addEventListener('scroll', () => {
+window.addEventListener('scroll', () => {
  clearTimeout(addTimeout)
  clearTimeout(removeTimeout)
- if (body.scrollTop < lastScrollY) {
+ if (window.scrollY < lastScrollY) {
   addTimeout = setTimeout(() =>
    body.classList.add('scroll-up')
   )
@@ -396,7 +396,7 @@ body.addEventListener('scroll', () => {
    500
   )
  }
- lastScrollY = body.scrollTop
+ lastScrollY = window.scrollY
  if (lastScrollY > 0) {
   body.classList.remove('scroll-zero')
  } else {


### PR DESCRIPTION
- Change html overflow from hidden to auto
- Remove body overflow and height constraints
- Update scroll event listeners to use window
- Update scrollToTop to use window.scrollTo
- Update captureScrollPosition/restoreScrollPosition to use window.scrollY